### PR TITLE
Add logBreadcrumb to AnalyticsHelper for PostHog breadcrumb trail

### DIFF
--- a/Sources/TTInAppPurchases/Helpers/AnalyticsHelper.swift
+++ b/Sources/TTInAppPurchases/Helpers/AnalyticsHelper.swift
@@ -95,13 +95,29 @@ public class AnalyticsHelper {
     /// - Important: Do NOT pass PII (phone numbers, recording URLs) in `message` or
     ///   `properties` — breadcrumbs are visible to the whole team in PostHog. Log
     ///   *what happened*, not *who*. Call only on meaningful transitions, never in loops.
+    /// - Note: `"category"` and `"message"` are reserved keys; any same-named entries
+    ///   in `properties` are overwritten by the `category`/`message` arguments.
     public func logBreadcrumb(_ message: String,
                               category: String = "navigation",
                               properties: [String: Any] = [:]) {
+        PostHogSDK.shared.capture("breadcrumb",
+                                  properties: Self.breadcrumbProperties(message,
+                                                                        category: category,
+                                                                        properties: properties))
+    }
+
+    /// Builds the property dictionary sent with a `breadcrumb` event. Pure and
+    /// side-effect free so it can be unit-tested without configuring or calling PostHog.
+    ///
+    /// `"category"` and `"message"` are reserved keys and overwrite any same-named
+    /// entries supplied by the caller.
+    static func breadcrumbProperties(_ message: String,
+                                     category: String,
+                                     properties: [String: Any] = [:]) -> [String: Any] {
         var props = properties
         props["category"] = category
         props["message"] = message
-        PostHogSDK.shared.capture("breadcrumb", properties: props)
+        return props
     }
 
     public func logRevenue(_ revenue: AMPRevenue) {

--- a/Sources/TTInAppPurchases/Helpers/AnalyticsHelper.swift
+++ b/Sources/TTInAppPurchases/Helpers/AnalyticsHelper.swift
@@ -87,6 +87,23 @@ public class AnalyticsHelper {
         
     }
     
+    // MARK: - Breadcrumbs
+
+    /// Logs a lightweight "breadcrumb" to PostHog to build a trail of the user's
+    /// actions/screens (visible in the Activity feed and as markers in session replay).
+    ///
+    /// - Important: Do NOT pass PII (phone numbers, recording URLs) in `message` or
+    ///   `properties` — breadcrumbs are visible to the whole team in PostHog. Log
+    ///   *what happened*, not *who*. Call only on meaningful transitions, never in loops.
+    public func logBreadcrumb(_ message: String,
+                              category: String = "navigation",
+                              properties: [String: Any] = [:]) {
+        var props = properties
+        props["category"] = category
+        props["message"] = message
+        PostHogSDK.shared.capture("breadcrumb", properties: props)
+    }
+
     public func logRevenue(_ revenue: AMPRevenue) {
         amplitudeInstance.logRevenueV2(revenue)
 //        mixpanelInstance.people.trackCharge(amount: revenue.price.doubleValue)

--- a/Tests/TTInAppPurchasesTests/TTInAppPurchasesTests.swift
+++ b/Tests/TTInAppPurchasesTests/TTInAppPurchasesTests.swift
@@ -3,10 +3,17 @@ import XCTest
 
 final class TTInAppPurchasesTests: XCTestCase {
     func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
+    }
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    /// Exercises the new breadcrumb API end-to-end through the real AnalyticsHelper
+    /// (which configures PostHog in its init). Proves logBreadcrumb runs without crashing
+    /// and accepts the message/category/properties shapes used at the app call sites.
+    func testLogBreadcrumbRunsWithoutCrashing() {
+        AnalyticsHelper.shared.logBreadcrumb("unit-test breadcrumb")
+        AnalyticsHelper.shared.logBreadcrumb("App launched", category: "lifecycle")
+        AnalyticsHelper.shared.logBreadcrumb("Transcription finished",
+                                             category: "transcription",
+                                             properties: ["result": "Success"])
+        XCTAssertTrue(true)
     }
 }

--- a/Tests/TTInAppPurchasesTests/TTInAppPurchasesTests.swift
+++ b/Tests/TTInAppPurchasesTests/TTInAppPurchasesTests.swift
@@ -2,18 +2,31 @@ import XCTest
 @testable import TTInAppPurchases
 
 final class TTInAppPurchasesTests: XCTestCase {
-    func testExample() throws {
+
+    /// `message` and `category` are folded into the breadcrumb properties.
+    /// Tests the pure property builder so nothing is sent to live PostHog.
+    func testBreadcrumbPropertiesMergesMessageAndCategory() {
+        let props = AnalyticsHelper.breadcrumbProperties("App launched", category: "lifecycle")
+        XCTAssertEqual(props["message"] as? String, "App launched")
+        XCTAssertEqual(props["category"] as? String, "lifecycle")
     }
 
-    /// Exercises the new breadcrumb API end-to-end through the real AnalyticsHelper
-    /// (which configures PostHog in its init). Proves logBreadcrumb runs without crashing
-    /// and accepts the message/category/properties shapes used at the app call sites.
-    func testLogBreadcrumbRunsWithoutCrashing() {
-        AnalyticsHelper.shared.logBreadcrumb("unit-test breadcrumb")
-        AnalyticsHelper.shared.logBreadcrumb("App launched", category: "lifecycle")
-        AnalyticsHelper.shared.logBreadcrumb("Transcription finished",
-                                             category: "transcription",
-                                             properties: ["result": "Success"])
-        XCTAssertTrue(true)
+    /// Caller-supplied properties are preserved alongside the reserved keys.
+    func testBreadcrumbPropertiesPreservesCustomProperties() {
+        let props = AnalyticsHelper.breadcrumbProperties("Transcription finished",
+                                                         category: "transcription",
+                                                         properties: ["result": "Success"])
+        XCTAssertEqual(props["result"] as? String, "Success")
+        XCTAssertEqual(props["message"] as? String, "Transcription finished")
+        XCTAssertEqual(props["category"] as? String, "transcription")
+    }
+
+    /// Reserved keys win: caller-supplied `category`/`message` are overwritten.
+    func testBreadcrumbReservedKeysOverrideCallerValues() {
+        let props = AnalyticsHelper.breadcrumbProperties("real message",
+                                                         category: "real",
+                                                         properties: ["category": "fake", "message": "fake"])
+        XCTAssertEqual(props["category"] as? String, "real")
+        XCTAssertEqual(props["message"] as? String, "real message")
     }
 }


### PR DESCRIPTION
## What
Adds a public `AnalyticsHelper.logBreadcrumb(_:category:properties:)` that captures a `breadcrumb` event to PostHog, building a labeled trail of user actions/screens (visible in the Activity feed and as markers in session replay).

## Why
The app (`CallRecorder`) PR [#201](https://github.com/sagar2305/CallRecorder/pull/201) adds breadcrumb logging at key user flows (app launch, home shown, outgoing call, recording playback, transcription start/finish, subscription screen). That PR depends on this API, which lives in this package — without this change the app will not compile.

## Implementation
- Uses the same `PostHogSDK.shared.capture(...)` path as existing `logEvent` calls — no new dependency, no new config.
- `category` defaults to `"navigation"`; `message` and `category` are folded into the event properties.
- Doc comment warns against passing PII (phone numbers, recording URLs) in breadcrumbs.
- Adds a unit test exercising the new API with the message/category/properties shapes used at the app call sites.

## Versioning
This is additive, backward-compatible new public API → minor bump. After merge, tag **`1.1.0`** (current latest tag is `1.0.0`) so the app can pin it.

## Verification
Built for iOS Simulator (iPhone 16 Pro, Xcode 26.5). `AnalyticsHelper.swift` compiles cleanly. Note: the build surfaces a **pre-existing, unrelated** error in `SKProductExtensions.swift:12` (`SubscriptionPeriod` ambiguous between StoreKit's new iOS 26.5 type and RevenueCat's) — that file is untouched by this PR and fails the same way on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added breadcrumb logging support to analytics, including a default navigation category, a message, and optional custom properties.
  * Breadcrumb details are sent as a dedicated analytics capture so they appear consistently in analytics.

* **Tests**
  * Added unit tests to verify breadcrumb property merging, including preservation of custom properties and correct overriding of reserved `message`/`category` keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->