### PR TITLE
Stable identity + recording analytics (package side)

### DIFF
--- a/Sources/TTInAppPurchases/Extensions/SKProductExtensions.swift
+++ b/Sources/TTInAppPurchases/Extensions/SKProductExtensions.swift
@@ -9,7 +9,7 @@ import StoreKit
 import RevenueCat
 
 
-extension SubscriptionPeriod.Unit {
+extension RevenueCat.SubscriptionPeriod.Unit {
     func description(capitalizeFirstLetter: Bool = false, numberOfUnits: Int? = nil) -> String {
         var unitString = String(describing: self)
         

--- a/Sources/TTInAppPurchases/Helpers/AnalyticsHelper.swift
+++ b/Sources/TTInAppPurchases/Helpers/AnalyticsHelper.swift
@@ -52,6 +52,30 @@ public class AnalyticsHelper {
 //        AppsFlyerLib.shared().customerUserID = userId
     }
 
+    /// Identifies a user who has NOT yet verified a phone number, using a stable
+    /// device identifier, so anonymous / onboarding users are trackable in PostHog
+    /// (and findable by that ID) instead of only appearing as a random anonymous id.
+    ///
+    /// Safe to call on every launch: PostHog only links the anonymous session to
+    /// `deviceId` the first time; later calls are no-ops. Once the user verifies a
+    /// number, call `aliasVerifiedUser(_:)` so the phone identity is merged in.
+    public func identifyAnonymousDevice(_ deviceId: String) {
+        PostHogSDK.shared.identify(deviceId,
+                                   userPropertiesSetOnce: [Constants.PostHog.dateOfFirstLogIn: Date().toISO()])
+    }
+
+    /// Links a freshly verified phone-number identity to the current PostHog person.
+    ///
+    /// `identify()` alone does NOT merge a user who is already identified (e.g. one
+    /// identified anonymously via `identifyAnonymousDevice(_:)`), so we alias the
+    /// phone number onto the current distinct id first, then run the normal
+    /// `setUserId(_:)` to update Amplitude / Mixpanel / PostHog person properties.
+    /// Call this once, right after a number is verified — not on every launch.
+    public func aliasVerifiedUser(_ userId: String) {
+        PostHogSDK.shared.alias(userId)
+        setUserId(userId)
+    }
+
     // MARK: - Event Logging
     public func logEvent(_ event: String) {
         amplitudeInstance.logEvent(event)

--- a/Sources/TTInAppPurchases/Helpers/Constants.swift
+++ b/Sources/TTInAppPurchases/Helpers/Constants.swift
@@ -275,6 +275,11 @@ public struct Constants {
         case userTappedPlayButton = "User Played Recording"
         case userTappedPauseButton = "User Paused Recording"
         case reviewPromptRequested = "App review prompt requested"
+
+        //recording capture (download + local save)
+        case recordingStarted = "Recording - Download Started"
+        case recordingSavedLocally = "Recording - Saved Locally"
+        case recordingFailed = "Recording - Failed"
         
         //transcription
         case transcriptionRequest = "Transcription - Transcription Requested"
@@ -429,6 +434,10 @@ public struct Constants {
         
         //recording API
         case dateQueryItem = "Query Date"
+
+        //recording capture (non-PII)
+        case recordingDirection = "Recording Direction"
+        case recordingDuration = "Recording Duration"
         
     }
 }


### PR DESCRIPTION
Package-side changes for the "make users findable in PostHog + richer analytics" work. Stacked on \`feature/posthog-breadcrumbs\`; app-side companion PR is in sagar2305/CallRecorder.

## Commits
1. **Fix build break: disambiguate SubscriptionPeriod to RevenueCat** — pre-existing, unrelated. Both StoreKit and RevenueCat now export \`SubscriptionPeriod\`, so \`extension SubscriptionPeriod.Unit\` was ambiguous and failed the whole app build. The only call site uses RevenueCat's \`StoreProduct\`, so it's now \`RevenueCat.SubscriptionPeriod.Unit\`.
2. **Analytics additions** (all additive):
   - \`AnalyticsHelper.identifyAnonymousDevice(_:)\` — identify pre-verification users by a stable device id.
   - \`AnalyticsHelper.aliasVerifiedUser(_:)\` — alias-then-identify to merge device-id → phone on verification. (PostHog \`identify()\` does not merge an already-identified user — verified via the SDK — so \`alias()\` is required.)
   - New \`AnalyticsEvent\` cases: \`recordingStarted\` / \`recordingSavedLocally\` / \`recordingFailed\`, plus non-PII property keys \`recordingDirection\`, \`recordingDuration\`.

## Notes
- No existing events renamed/removed; verified-user phone identity unchanged.
- App device build (\`generic/platform=iOS\`) succeeds with the companion app PR checked out at \`../\`.
- Pre-existing behavior unchanged: raw phone numbers are still the analytics identity for verified users (PII); flagged for a possible future hashing change, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved account identity handling during onboarding and after verification, helping keep activity linked to the right profile.
  * Added tracking for recording activity, including when a recording starts, is saved locally, or fails.
* **Bug Fixes**
  * Refined subscription period handling for more consistent behavior across supported products.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->